### PR TITLE
Removes introduction of whitespace in hits view rendering

### DIFF
--- a/src/main/java/eu/clarin/sru/server/fcs/AdvancedDataViewWriter.java
+++ b/src/main/java/eu/clarin/sru/server/fcs/AdvancedDataViewWriter.java
@@ -307,24 +307,14 @@ public class AdvancedDataViewWriter {
         writer.setPrefix(FCS_HITS_PREFIX, FCS_HITS_NS);
         writer.writeStartElement(FCS_HITS_NS, "Result");
         writer.writeNamespace(FCS_HITS_PREFIX, FCS_HITS_NS);
-        boolean needSpace = false;
         for (Span span : spans) {
             if (span.value.length() > 0) {
-                if (needSpace) {
-                    writer.writeCharacters(" ");
-                    needSpace = false;
-                }
                 if (span.highlight != null) {
                     writer.writeStartElement(FCS_HITS_NS, "Hit");
                     writer.writeCharacters(span.value);
                     writer.writeEndElement(); // "Hit" element
-                    needSpace = true;
                 } else {
                     writer.writeCharacters(span.value);
-                    if (!Character.isWhitespace(
-                            (span.value.charAt(span.value.length() - 1)))) {
-                        needSpace = true;
-                    }
                 }
             }
         }


### PR DESCRIPTION
The rendering of the hits view in `AdvanceDataViewWriter` is derived from a given layer whose span values are assumed to already contain whitespace at the end. Therefore the introduction of additional whitespace, controlled via the flag `needSpace` duplicates existing whitespace.